### PR TITLE
Fix for SLTP stop order which uses percent units

### DIFF
--- a/roffild.lua
+++ b/roffild.lua
@@ -530,12 +530,12 @@ function roffild.sendStopOrder(stop_order)
         trans.OPERATION = "S"
     end
     if (stop_order.stopflags & 0x8) ~= 0 then
+        trans.OFFSET = roffild.roundPrice(stop_order.offset, 2)
         trans.OFFSET_UNITS = "PERCENTS"
-        trans.OFFSET = tostring(stop_order.offset)
     end
     if (stop_order.stopflags & 0x10) ~= 0 then
+        trans.SPREAD = roffild.roundPrice(stop_order.spread, 2)
         trans.SPREAD_UNITS = "PERCENTS"
-        trans.SPREAD = tostring(stop_order.spread)
     end
     if tonumber(stop_order.expiry) <= tonumber(os.date("%Y%m%d")) then
         trans.EXPIRY_DATE = "TODAY"

--- a/roffild.lua
+++ b/roffild.lua
@@ -531,9 +531,11 @@ function roffild.sendStopOrder(stop_order)
     end
     if (stop_order.stopflags & 0x8) ~= 0 then
         trans.OFFSET_UNITS = "PERCENTS"
+        trans.OFFSET = tostring(stop_order.offset)
     end
     if (stop_order.stopflags & 0x10) ~= 0 then
         trans.SPREAD_UNITS = "PERCENTS"
+        trans.SPREAD = tostring(stop_order.spread)
     end
     if tonumber(stop_order.expiry) <= tonumber(os.date("%Y%m%d")) then
         trans.EXPIRY_DATE = "TODAY"


### PR DESCRIPTION
Если указывать в createOrder() параметры offset и spread в процентах, то quik будет выкидывать ошибку, так как будет относиться к процентам, как к цене и округлять её.

```
---@param offset? number|string Отступ от min (10 или "10%")
---@param spread? number|string Защитный спред (10 или "10%")
```